### PR TITLE
簡単なヘッダーの作成

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { Routes, Route } from "react-router-dom";
 
+import Header from "./components/Header"
 import Home from "./components/Home";
 import Profile from "./components/Profile";
 
 function App() {
   return (
     <div className="App">
+      <Header/>
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/profile" element={<Profile />} />

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router-dom';
+
+interface SessionSuggestionPost {
+  technology: string,
+  likes: number,
+  date: Date,
+}
+
+function Header() {
+
+  return <header>
+		<div className="d-flex px-3 py-1 border-bottom border-dark">
+			<Link to="/" className='text-decoration-none my-auto'>
+				<h1 className="my-0">SkillHub</h1>
+			</Link>
+			<div className="ml-auto my-auto">
+				<Link to="/profile">
+					<img className='border border-dark rounded-circle' src="http://localhost:3000/logo192.png" width={50}/>
+				</Link>
+			</div>
+		</div>
+  </header>
+}
+
+export default Header;


### PR DESCRIPTION
## 対応issueのリンク

https://github.com/YoshiYoshiPro/SkillHub/issues/32

## やったこと

どの画面においてもヘッダが表示されるように

## できるようになること（ユーザ目線）

表示されているヘッダからいつでもホーム画面・プロフィール画面に飛ぶことができる

## 動作確認

ホーム画面でヘッダの右の画像をクリックするとプロフィール画面にとび、
プロフィール画面でヘッダの左のSkillHubをクリックするとホーム画面にとぶ

<img width="1044" alt="スクリーンショット 2023-09-05 18 28 39" src="https://github.com/YoshiYoshiPro/SkillHub/assets/136701385/fdf58e9b-0ba6-4552-b486-7e53c5f1ab3c">

<img width="1039" alt="スクリーンショット 2023-09-05 18 28 48" src="https://github.com/YoshiYoshiPro/SkillHub/assets/136701385/95bf705d-0dd0-4934-b016-50236932707f">


## その他

ヘッダのSkillHubはロゴ画像であるべきか(現在はただのh1タグ)