### PR TITLE
Feature/front back tag search dummy

### DIFF
--- a/backend/fastapi/controllers.py
+++ b/backend/fastapi/controllers.py
@@ -26,14 +26,23 @@ def get_data(request: Request):
     return {"key": "value","message":"Hello from FastAPI!"}
 
 
-def get_tag_result(request: Request):
+def get_tag_result(request: Request, tag):
     return {
         "is_accepted": True,
     	"interests": [
-            {"user_id": "aaa", "name": "あああ", "icon_url": "http://localhost:3000/logo192.png"},
+            {"user_id": tag, "name": tag, "icon_url": "http://localhost:3000/logo192.png"},
             {"user_id": "bbb", "name": "いいい", "icon_url": "http://localhost:3000/logo192.png"},
             {"user_id": "ccc", "name": "ううう", "icon_url": "http://localhost:3000/logo192.png"},
         ],
-	    "expertises": [],
-	    "experiences": [],
+	    "expertises": [
+            {"user_id": "ccc", "name": "ううう", "icon_url": "http://localhost:3000/logo192.png", "years": 8},
+            {"user_id": "ddd", "name": "えええ", "icon_url": "http://localhost:3000/logo192.png", "years": 13},
+        ],
+	    "experiences": [
+            {"user_id": "aaa", "name": "あああ", "icon_url": "http://localhost:3000/logo192.png", "years": 1},
+            {"user_id": "bbb", "name": "いいい", "icon_url": "http://localhost:3000/logo192.png", "years": 2},
+            {"user_id": "ccc", "name": "ううう", "icon_url": "http://localhost:3000/logo192.png", "years": 8},
+            {"user_id": "ddd", "name": "えええ", "icon_url": "http://localhost:3000/logo192.png", "years": 13},
+            {"user_id": "eee", "name": "おおお", "icon_url": "http://localhost:3000/logo192.png", "years": 5},
+        ],
     }

--- a/backend/fastapi/controllers.py
+++ b/backend/fastapi/controllers.py
@@ -24,3 +24,16 @@ def index(request: Request):
 
 def get_data(request: Request):
     return {"key": "value","message":"Hello from FastAPI!"}
+
+
+def get_tag_result(request: Request):
+    return {
+        "is_accepted": True,
+    	"interests": [
+            {"user_id": "aaa", "name": "あああ", "icon_url": "http://localhost:3000/logo192.png"},
+            {"user_id": "bbb", "name": "いいい", "icon_url": "http://localhost:3000/logo192.png"},
+            {"user_id": "ccc", "name": "ううう", "icon_url": "http://localhost:3000/logo192.png"},
+        ],
+	    "expertises": [],
+	    "experiences": [],
+    }

--- a/backend/fastapi/urls.py
+++ b/backend/fastapi/urls.py
@@ -9,4 +9,5 @@ app.add_api_route('/data',get_data)
 # # プロフィールの表示
 # app.add_api_route('/get-profile',get_profile)
 
-app.add_api_route('/search-tag', get_tag_result)
+# タグ検索リクエスト
+app.add_api_route('/search-tag/{tag}', get_tag_result)

--- a/backend/fastapi/urls.py
+++ b/backend/fastapi/urls.py
@@ -8,3 +8,5 @@ app.add_api_route('/data',get_data)
 
 # # プロフィールの表示
 # app.add_api_route('/get-profile',get_profile)
+
+app.add_api_route('/search-tag', get_tag_result)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@types/react-bootstrap": "^0.32.32",
     "@types/react-dom": "^18.0.0",
     "@types/react-router-dom": "^5.3.3",
+    "axios": "^1.5.0",
     "bootstrap": "4.6.0",
     "react": "^18.2.0",
     "react-bootstrap": "^2.8.0",

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -12,8 +12,8 @@ interface SessionSuggestionPost {
 interface SearchTagResponse {
 	is_accepted: boolean,
 	interests: {user_id: string, name: string, icon_url: string}[],
-	expertises: {user_id: string, name: string, icon_url: string}[],
-	experiences: {user_id: string, name: string, icon_url: string}[],
+	expertises: {user_id: string, name: string, icon_url: string, years: number}[],
+	experiences: {user_id: string, name: string, icon_url: string, years: number}[],
 }
 
 
@@ -23,8 +23,8 @@ function Home() {
   const [tag, setTag] = useState("");
 
   const [interests, setInterests] = useState([] as {user_id: string, name: string, icon_url: string}[]);
-  const [expertises, setExpertises] = useState([] as {user_id: string, name: string, icon_url: string}[]);
-  const [experiences, setExperiences] = useState([] as {user_id: string, name: string, icon_url: string}[]);
+  const [expertises, setExpertises] = useState([] as {user_id: string, name: string, icon_url: string, years: number}[]);
+  const [experiences, setExperiences] = useState([] as {user_id: string, name: string, icon_url: string, years: number}[]);
 
   const data = [
     { name: "1年目", year: 30 },
@@ -77,7 +77,7 @@ function Home() {
   ];
 
   const search_tag = (tag: string) => {
-    axios.get('http://localhost:8000/search-tag')
+    axios.get('http://localhost:8000/search-tag/' + tag)
     .then((res) => {
       const search_tag_res: SearchTagResponse = res.data;
       if(search_tag_res.is_accepted) {
@@ -133,6 +133,50 @@ function Home() {
                     <YAxis />
                     <Bar dataKey="year" barSize={20} fill="red" />
                   </ComposedChart>
+                </div>
+
+                <h4 className="mt-4 mb-0 ml-2">業務経験のある人</h4>
+                <div className="d-flex flex-wrap">
+                  {expertises.map((expertise) => {
+                    return (
+                      <div className="col-6 p-0">
+                        <div className="m-2 p-1 border border-gray rounded d-flex">
+                          <img
+                            className="border border-dark rounded-circle m-1"
+                            src={expertise.icon_url}
+                            width={50}
+                          />
+                          <div className="my-auto">
+                            <h4 className="m-0">{expertise.name}</h4>
+                            <p className="m-0">{expertise.user_id}</p>
+                          </div>
+                          <h4 className="ml-auto mr-2 my-auto">{expertise.years}年目</h4>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <h4 className="mt-4 mb-0 ml-2">得意な人</h4>
+                <div className="d-flex flex-wrap">
+                  {experiences.map((experience) => {
+                    return (
+                      <div className="col-6 p-0">
+                        <div className="m-2 p-1 border border-gray rounded d-flex">
+                          <img
+                            className="border border-dark rounded-circle m-1"
+                            src={experience.icon_url}
+                            width={50}
+                          />
+                          <div className="my-auto">
+                            <h4 className="m-0">{experience.name}</h4>
+                            <p className="m-0">{experience.user_id}</p>
+                          </div>
+                          <h4 className="ml-auto mr-2 my-auto">{experience.years}年目</h4>
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
 
                 <h4 className="mt-4 mb-0 ml-2">興味のある人</h4>

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -1,14 +1,31 @@
 import { useState } from "react";
+import axios from 'axios';
 import Modal from "react-bootstrap/Modal";
 import { ComposedChart, CartesianGrid, XAxis, YAxis, Bar } from "recharts";
+
 interface SessionSuggestionPost {
   technology: string;
   likes: number;
   date: Date;
 }
 
+interface SearchTagResponse {
+	is_accepted: boolean,
+	interests: {user_id: string, name: string, icon_url: string}[],
+	expertises: {user_id: string, name: string, icon_url: string}[],
+	experiences: {user_id: string, name: string, icon_url: string}[],
+}
+
+
 function Home() {
   const [is_searching, setIsSearching] = useState(false);
+  const [is_searched, setIsSearched] = useState(false);
+  const [tag, setTag] = useState("");
+
+  const [interests, setInterests] = useState([] as {user_id: string, name: string, icon_url: string}[]);
+  const [expertises, setExpertises] = useState([] as {user_id: string, name: string, icon_url: string}[]);
+  const [experiences, setExperiences] = useState([] as {user_id: string, name: string, icon_url: string}[]);
+
   const data = [
     { name: "1年目", year: 30 },
     { name: "2年目", year: 83 },
@@ -59,6 +76,22 @@ function Home() {
     },
   ];
 
+  const search_tag = (tag: string) => {
+    axios.get('http://localhost:8000/search-tag')
+    .then((res) => {
+      const search_tag_res: SearchTagResponse = res.data;
+      if(search_tag_res.is_accepted) {
+        setIsSearched(true);
+        setInterests(search_tag_res.interests);
+        setExpertises(search_tag_res.expertises);
+        setExperiences(search_tag_res.experiences);
+      }
+    })
+    .catch((err) => {
+      console.log(err);
+    });
+  }
+
   return (
     <>
       <Modal show={is_searching} size="lg" onHide={() => setIsSearching(false)}>
@@ -69,13 +102,15 @@ function Home() {
               <input
                 type="text"
                 className="px-3 py-2 m-0 col-9 border border-gray rounded-pill h3"
+                value={tag}
+                onChange={(e) => {setTag(e.target.value)}}
               />
             </div>
             <div className="d-flex mb-2">
               <div className="col-9 d-flex ml-auto px-2 py-2 lh-auto border border-gray rounded">
                 {trending_technologies.map((technology) => {
                   return (
-                    <button className="btn btn-link p-0 mx-2">
+                    <button className="btn btn-link p-0 mx-2" onClick={() => {search_tag(technology)}}>
                       #{technology}
                     </button>
                   );
@@ -83,39 +118,45 @@ function Home() {
               </div>
             </div>
 
-            <div className="d-flex">
-              <ComposedChart
-                width={600}
-                height={300}
-                data={data}
-                margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
-              >
-                <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
-                <XAxis dataKey="name" />
-                <YAxis />
-                <Bar dataKey="year" barSize={20} fill="red" />
-              </ComposedChart>
-            </div>
+            {
+              is_searched &&
+              <div>
+                <div className="d-flex">
+                  <ComposedChart
+                    width={600}
+                    height={300}
+                    data={data}
+                    margin={{ top: 5, right: 20, bottom: 5, left: 0 }}
+                  >
+                    <CartesianGrid stroke="#ccc" strokeDasharray="5 5" />
+                    <XAxis dataKey="name" />
+                    <YAxis />
+                    <Bar dataKey="year" barSize={20} fill="red" />
+                  </ComposedChart>
+                </div>
 
-            <div className="d-flex flex-wrap">
-              {tmp_users.map((user) => {
-                return (
-                  <div className="col-6 p-0">
-                    <div className="m-2 p-1 border border-gray rounded d-flex">
-                      <img
-                        className="border border-dark rounded-circle m-1"
-                        src={user.icon_url}
-                        width={50}
-                      />
-                      <div className="my-auto">
-                        <h4 className="m-0">{user.name}</h4>
-                        <p className="m-0">{user.id}</p>
+                <h4 className="mt-4 mb-0 ml-2">興味のある人</h4>
+                <div className="d-flex flex-wrap">
+                  {interests.map((interest) => {
+                    return (
+                      <div className="col-6 p-0">
+                        <div className="m-2 p-1 border border-gray rounded d-flex">
+                          <img
+                            className="border border-dark rounded-circle m-1"
+                            src={interest.icon_url}
+                            width={50}
+                          />
+                          <div className="my-auto">
+                            <h4 className="m-0">{interest.name}</h4>
+                            <p className="m-0">{interest.user_id}</p>
+                          </div>
+                        </div>
                       </div>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
+                    );
+                  })}
+                </div>
+              </div>
+            }
           </div>
         </Modal.Body>
         <Modal.Footer>

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -53,29 +53,6 @@ function Home() {
 
   const trending_technologies = ["SolidJS", "Three.JS", "Golang"];
 
-  const tmp_users = [
-    {
-      id: "111111",
-      name: "テスト男",
-      icon_url: "http://localhost:3000/logo192.png",
-    },
-    {
-      id: "222222",
-      name: "テスト女",
-      icon_url: "http://localhost:3000/logo192.png",
-    },
-    {
-      id: "333333",
-      name: "テスト爺",
-      icon_url: "http://localhost:3000/logo192.png",
-    },
-    {
-      id: "444444",
-      name: "テスト婆",
-      icon_url: "http://localhost:3000/logo192.png",
-    },
-  ];
-
   const search_tag = (tag: string) => {
     axios.get('http://localhost:8000/search-tag/' + tag)
     .then((res) => {

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -59,6 +59,7 @@ function Home() {
       const search_tag_res: SearchTagResponse = res.data;
       if(search_tag_res.is_accepted) {
         setIsSearched(true);
+        setTag(tag);
         setInterests(search_tag_res.interests);
         setExpertises(search_tag_res.expertises);
         setExperiences(search_tag_res.experiences);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2956,6 +2956,15 @@ axe-core@^4.6.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.2.tgz#040a7342b20765cb18bb50b628394c21bccc17a0"
   integrity sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==
 
+axios@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.5.0.tgz#f02e4af823e2e46a9768cfc74691fdd0517ea267"
+  integrity sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^3.1.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-3.2.1.tgz#39c378a6e3b06ca679f29138151e45b2b32da62a"
@@ -4898,7 +4907,7 @@ flatted@^3.2.7:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -4933,6 +4942,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -7872,6 +7890,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.9.0"


### PR DESCRIPTION
## 対応issueのリンク

https://github.com/YoshiYoshiPro/SkillHub/issues/48

## やったこと

バックからタグ検索結果のダミーデータを受け取り表示させる

## できるようになること（ユーザ目線）

タグ検索した際に、興味のある人、業務経験のある人、得意な人の一覧が表示される

## 動作確認

検索モーダルで適当なタグをクリックし、一覧が表示された
<img width="853" alt="スクリーンショット 2023-09-06 16 08 31" src="https://github.com/YoshiYoshiPro/SkillHub/assets/136701385/bf0d8998-23a1-4ce0-b51d-e1cf746bdb6b">
<img width="646" alt="スクリーンショット 2023-09-06 16 08 20" src="https://github.com/YoshiYoshiPro/SkillHub/assets/136701385/850c6d86-8b2c-483c-972b-62efdc21b2ed">


## その他

この情報をグラフに適用させる