### PR TITLE
ダミーデータのタグサジェストをフロントはバックから取得できるように

### DIFF
--- a/backend/fastapi/controllers.py
+++ b/backend/fastapi/controllers.py
@@ -62,3 +62,11 @@ def get_tag_result(request: Request, tag):
             {"user_id": "eee", "name": "おおお", "icon_url": "http://localhost:3000/logo192.png", "years": 5},
         ],
     }
+
+
+def get_suggested_tags(request: Request, tag_substring):
+    tmp_tags = ["Java", "JavaScript", "SolidJS", "Three.JS", "Golang"]
+
+    return {
+    	"suggested_tags": [tag for tag in tmp_tags if tag_substring in tag],
+    }

--- a/backend/fastapi/controllers.py
+++ b/backend/fastapi/controllers.py
@@ -5,8 +5,8 @@ from sqlalchemy.orm import Session
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 
-from core import config
-from crud import crud
+'''from core import config
+from crud import crud'''
 from fastapi import Depends, FastAPI, HTTPException
 
 # from migration import database, models

--- a/backend/fastapi/crud/crud.py
+++ b/backend/fastapi/crud/crud.py
@@ -1,7 +1,7 @@
 from sqlalchemy.orm import Session
 
-from ..migration import models
-from ..schemas import schemas
+'''from ..migration import models
+from ..schemas import schemas'''
 
 
 # For Users

--- a/backend/fastapi/urls.py
+++ b/backend/fastapi/urls.py
@@ -9,6 +9,8 @@ app.add_api_route('/data',get_data)
 # # プロフィールの表示
 # app.add_api_route('/get-profile',get_profile)
 
-
 # タグ検索リクエスト
 app.add_api_route('/search-tag/{tag}', get_tag_result)
+
+# タグサジェストリクエスト
+app.add_api_route('/get-suggested-tags/{tag_substring}', get_suggested_tags)

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -16,11 +16,16 @@ interface SearchTagResponse {
 	experiences: {user_id: string, name: string, icon_url: string, years: number}[],
 }
 
+interface GetSuggestedTagsResponse {
+  suggested_tags: string[],
+}
+
 
 function Home() {
   const [is_searching, setIsSearching] = useState(false);
   const [is_searched, setIsSearched] = useState(false);
   const [tag, setTag] = useState("");
+  const [suggested_tags, setSuggestedTags] = useState(["SolidJS", "Three.JS", "Golang"]);
 
   const [interests, setInterests] = useState([] as {user_id: string, name: string, icon_url: string}[]);
   const [expertises, setExpertises] = useState([] as {user_id: string, name: string, icon_url: string, years: number}[]);
@@ -70,6 +75,17 @@ function Home() {
     });
   }
 
+  const get_suggested_tags = (tag_substring: string) => {
+    axios.get('http://localhost:8000/get-suggested-tags/' + tag_substring)
+    .then((res) => {
+      const get_suggested_tags_res: GetSuggestedTagsResponse = res.data;
+      setSuggestedTags(get_suggested_tags_res.suggested_tags);
+    })
+    .catch((err) => {
+      console.log(err);
+    });
+  }
+
   return (
     <>
       <Modal show={is_searching} size="lg" onHide={() => setIsSearching(false)}>
@@ -81,15 +97,18 @@ function Home() {
                 type="text"
                 className="px-3 py-2 m-0 col-9 border border-gray rounded-pill h3"
                 value={tag}
-                onChange={(e) => {setTag(e.target.value)}}
+                onChange={(e) => {
+                  setTag(e.target.value);
+                  get_suggested_tags(e.target.value);
+                }}
               />
             </div>
             <div className="d-flex mb-2">
               <div className="col-9 d-flex ml-auto px-2 py-2 lh-auto border border-gray rounded">
-                {trending_technologies.map((technology) => {
+                {suggested_tags.map((tag) => {
                   return (
-                    <button className="btn btn-link p-0 mx-2" onClick={() => {search_tag(technology)}}>
-                      #{technology}
+                    <button className="btn btn-link p-0 mx-2" onClick={() => {search_tag(tag)}}>
+                      #{tag}
                     </button>
                   );
                 })}


### PR DESCRIPTION
## 対応issueのリンク

https://github.com/YoshiYoshiPro/SkillHub/issues/47

## やったこと

バックからタグサジェスト結果のダミーデータを受け取り表示させる

## できるようになること（ユーザ目線）

タグサジェスト

## 動作確認

サジェストができた
