### PR TITLE
feat: ✨ フロントエンドからGETでユーザーのエンドポイント叩く

### DIFF
--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { auth, provider } from "../firebase";
-import { signInWithPopup } from "firebase/auth";
+import { signInWithPopup, getAuth, getIdToken } from "firebase/auth";
+
+const FASTAPI_ENDPOINT = "http://localhost:8000";
 
 const Login: React.FC = () => {
   const navigate = useNavigate();
@@ -9,7 +11,11 @@ const Login: React.FC = () => {
 
   const handleLogin = async (event: React.MouseEvent<HTMLButtonElement>) => {
     try {
-      await signInWithPopup(auth, provider);
+      const result = await signInWithPopup(auth, provider);
+      const token = await getIdToken(result.user);
+      console.log("ID Token:", token);
+      // FastAPI エンドポイントにリクエストを送信
+      await sendRequestToBackend(token);
       navigate("/");
     } catch (error) {
       if (error instanceof Error) {
@@ -22,6 +28,17 @@ const Login: React.FC = () => {
         setError("An unknown error occurred.");
       }
     }
+  };
+
+  const sendRequestToBackend = async (token: string) => {
+    const response = await fetch(FASTAPI_ENDPOINT, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const data = await response.json();
+    console.log(data);
   };
 
   return (


### PR DESCRIPTION
## 対応issueのリンク

* #67 

## やったこと

* フロントエンド側からユーザー情報保存のエンドポイントを叩く機能追加
* フロントエンド側の認証処理は終了


## 動作確認

<img width="1160" alt="image" src="https://github.com/YoshiYoshiPro/SkillHub/assets/106864912/eda041fc-695e-4d5b-8d98-4284e36f53f7">
