### PR TITLE
サジェストで返す技術をダミーではなく本物に

### DIFF
--- a/backend/fastapi/controllers.py
+++ b/backend/fastapi/controllers.py
@@ -151,14 +151,13 @@ def get_tec_result(request: Request, tec_id: int):
     }
 
 
-def get_suggested_tecs(request: Request, tec_substring):
-    tmp_tecs = ["Java", "JavaScript", "SolidJS", "Three.JS", "Golang"]
+def get_suggested_tecs(request: Request, tec_substring: str, db: Session = Depends(get_db)):
+    tecs = db.query(models.Technologies).filter(models.Technologies.name.contains(tec_substring)).all()
 
     return {
         "tecs": [
-            {"id": 1, "name": tec_name}
-            for tec_name in tmp_tecs
-            if tec_substring in tec_name
+            {"id": tec.id, "name": tec.name}
+            for tec in tecs
         ],
     }
 


### PR DESCRIPTION
## 対応issueのリンク

https://github.com/YoshiYoshiPro/SkillHub/issues/94

## やったこと

サジェストをダミーではなく本物に

## できるようになること（ユーザ目線）

本物の技術のサジェストが得られる

## 動作確認

DBに登録されている技術がサジェストとして表示された